### PR TITLE
Add back in some Docker platforms that were previously removed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,13 +29,13 @@ env:
   CURL_CACHE_DIR: ~/.cache/curl
   IMAGE_NAME: cisagov/trustymail_reporter
   PIP_CACHE_DIR: ~/.cache/pip
-  # The Debian Stretch + Python 3.6 Docker container upon which this
-  # container is based does not support all the platforms listed
-  # below.  This can probably be remedied by upgrading to a newer base
-  # container.  See #45 for more details.
+  # Not all these platforms can be built in the six hour time limit
+  # imposed by GitHub Actions, so we remove the two most obscure
+  # platforms.
   # PLATFORMS: "linux/amd64,linux/arm/v6,linux/arm/v7,\
   # linux/arm64,linux/ppc64le,linux/s390x"
-  PLATFORMS: "linux/amd64,linux/arm/v7,linux/arm64"
+  PLATFORMS: "linux/amd64,linux/arm/v6,linux/arm/v7,\
+  linux/arm64"
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds back into the GitHub Actions workflow the building of the Docker image for some of the Docker hardware platforms that were previously removed.

## 💭 Motivation and context ##

Now that this Docker image is based on a newer base image, these other platforms can be built.  Note, however, that not all platforms can be built within the six hour time limit imposed by GitHub Actions; therefore, we continue to drop a few of the most obscure platforms.

## 🧪 Testing ##

Automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.